### PR TITLE
Change wrapper to page

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -21,7 +21,7 @@ Enjoy your theme!
 </head>
 <body{% block body_start %}{% endblock %} class="{{ 'antialiased'|tabler_body }}">
 {% block after_body_start %}{% endblock %}
-<div class="wrapper">
+<div class="page">
     <header class="navbar navbar-expand-md{% block header_class %} {% if tabler_bundle.isNavbarOverlapping() %}navbar-dark navbar-overlap{% else %}navbar-light{% endif %}{% endblock %} d-print-none">
         <div class="{{ ''|tabler_container }}">
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu">


### PR DESCRIPTION
## Description
In case of the footer that is not on the bottom of the page, the only diff I've found with the demo is that class.
https://preview.tabler.io/empty.html

Maybe BC Break ? not on my side.

Note: in the full-page, we have already changed that class.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I updated the documentation (see [here](https://github.com/kevinpapst/TablerBundle/tree/master/docs))
- [x] I agree that this code will be published under the [MIT license](https://github.com/kevinpapst/TablerBundle/blob/master/LICENSE)
